### PR TITLE
OJORISE-82-add-user-api

### DIFF
--- a/src/main/java/com/uplus/ojorise/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/uplus/ojorise/config/JwtAuthenticationFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthenticationFilter implements Filter {
                 || path.startsWith("/ojoRise/swagger-resources")
                 || path.startsWith("/ojoRise/webjars")
                 || path.equals("/ojoRise/swagger-ui.html")
+                || path.equals("/ojoRise/google/ocr")
                 || path.startsWith("/ojoRise/plan")
                 || path.contains("favicon")
                 || path.startsWith("/ojoRise/error")

--- a/src/main/java/com/uplus/ojorise/config/SecurityConfig.java
+++ b/src/main/java/com/uplus/ojorise/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
                                 "/auth/kakao/**",
                                 "/auth/refresh",
                                 "/error",
-                                "/plan/**"
+                                "/plan/**",
+                                "/google/ocr"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/uplus/ojorise/controller/DipPlanController.java
+++ b/src/main/java/com/uplus/ojorise/controller/DipPlanController.java
@@ -33,4 +33,12 @@ public class DipPlanController {
         dipPlanService.delete(userId.intValue(), planId);
         return ResponseEntity.ok("찜한 요금제가 성공적으로 삭제되었습니다.");
     }
+
+    @PutMapping("/{planId}")
+    @Operation(summary = "찜한 요금제 추가", description = "사용자가 찜한 특정 요금제를 추가합니다.")
+    public ResponseEntity<String> updateDippedPlan(@PathVariable int planId, Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        dipPlanService.insert(userId.intValue(), planId);
+        return ResponseEntity.ok("찜한 요금제가 성공적으로 추가되었습니다.");
+    }
 }

--- a/src/main/java/com/uplus/ojorise/controller/ProfileController.java
+++ b/src/main/java/com/uplus/ojorise/controller/ProfileController.java
@@ -1,0 +1,24 @@
+package com.uplus.ojorise.controller;
+
+import com.uplus.ojorise.domain.Profile;
+import com.uplus.ojorise.service.ProfileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    public ProfileController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<Profile> getProfile(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(profileService.getProfile(userId.intValue()));
+    }
+}

--- a/src/main/java/com/uplus/ojorise/controller/UserController.java
+++ b/src/main/java/com/uplus/ojorise/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.uplus.ojorise.controller;
+
+import com.uplus.ojorise.client.PythonClient;
+import com.uplus.ojorise.domain.Plan;
+import com.uplus.ojorise.domain.Profile;
+import com.uplus.ojorise.service.PlanService;
+import com.uplus.ojorise.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+import java.util.*;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/user")
+    public ResponseEntity<Boolean> getUserIsSurvey(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(userService.getUserIsSurvey(userId));
+    }
+}
+

--- a/src/main/java/com/uplus/ojorise/domain/Profile.java
+++ b/src/main/java/com/uplus/ojorise/domain/Profile.java
@@ -1,0 +1,19 @@
+package com.uplus.ojorise.domain;
+
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Profile {
+    private int id;
+    private Date birthdate;
+    private String telecomProvider;
+    private String planName;
+    private String familyBundle;
+    private String tongResult;
+}

--- a/src/main/java/com/uplus/ojorise/mapper/DipPlanMapper.java
+++ b/src/main/java/com/uplus/ojorise/mapper/DipPlanMapper.java
@@ -19,4 +19,7 @@ public interface DipPlanMapper {
 
     @Delete("DELETE FROM dipplan WHERE id = #{id} AND plan_id = #{planId}")
     void delete(@Param("id") int id, @Param("planId") int planId);
+
+    @Insert("INSERT INTO dipplan(id, plan_id) VALUES (#{id}, #{planId})")
+    void insert(@Param("id") int id, @Param("planId") int planId);
 }

--- a/src/main/java/com/uplus/ojorise/mapper/ProfileMapper.java
+++ b/src/main/java/com/uplus/ojorise/mapper/ProfileMapper.java
@@ -1,0 +1,12 @@
+package com.uplus.ojorise.mapper;
+
+import com.uplus.ojorise.domain.Profile;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ProfileMapper {
+    Profile getProfile(
+            @Param("id") int id
+    );
+}

--- a/src/main/java/com/uplus/ojorise/mapper/UserMapper.java
+++ b/src/main/java/com/uplus/ojorise/mapper/UserMapper.java
@@ -8,8 +8,8 @@ public interface UserMapper {
     User findByKakaoId(String kakaoId);
     User findByUserId(Long userId);
     void insertUser(User user);
-    void deleteByUserId(Long userId);
     void markSurvey(Long userId);
     void markWithdraw(Long userId);
     void cancelWithdraw(Long userId);
+    boolean getUserIsSurvey(Long userId);
 }

--- a/src/main/java/com/uplus/ojorise/service/DipPlanService.java
+++ b/src/main/java/com/uplus/ojorise/service/DipPlanService.java
@@ -20,4 +20,6 @@ public class DipPlanService {
     public void delete(int id, int planId) {
         dipPlanMapper.delete(id, planId);
     }
+
+    public void insert(int id, int planId) { dipPlanMapper.insert(id, planId); }
 }

--- a/src/main/java/com/uplus/ojorise/service/ProfileService.java
+++ b/src/main/java/com/uplus/ojorise/service/ProfileService.java
@@ -1,0 +1,16 @@
+package com.uplus.ojorise.service;
+
+import com.uplus.ojorise.domain.Profile;
+import com.uplus.ojorise.mapper.ProfileMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+    private final ProfileMapper profileMapper;
+
+    public Profile getProfile(int id) {
+        return profileMapper.getProfile(id);
+    }
+}

--- a/src/main/java/com/uplus/ojorise/service/UserService.java
+++ b/src/main/java/com/uplus/ojorise/service/UserService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
     private final KakaoApiService kakaoApiService;
     private final UserMapper userMapper;
     private final TokenMapper tokenMapper;
@@ -55,4 +54,6 @@ public class UserService {
     public void completeSurvey(Long userId) {
         userMapper.markSurvey(userId);
     }
+
+    public boolean getUserIsSurvey(Long userId) { return userMapper.getUserIsSurvey(userId); };
 }

--- a/src/main/resources/mapper/ProfileMapper.xml
+++ b/src/main/resources/mapper/ProfileMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.uplus.ojorise.mapper.ProfileMapper">
+    <resultMap id="ProfileResultMap" type="com.uplus.ojorise.domain.Profile">
+        <id     property="id"               column="id" />
+        <result property="birthdate"        column="birthdate" />
+        <result property="telecomProvider"  column="telecom_provider" />
+        <result property="planName"         column="plan_name" />
+        <result property="familyBundle"     column="family_bundle" />
+        <result property="tongResult"       column="tong_result" />
+    </resultMap>
+
+    <select id="getProfile" resultMap="ProfileResultMap" parameterType="int">
+        SELECT
+            u.id AS id,
+            s.birthdate AS birthdate,
+            s.telecom_provider AS telecom_provider,
+            s.plan_name AS plan_name,
+            s.family_bundle AS family_bundle,
+            t.tong_result AS tong_result
+        FROM user u
+                 LEFT JOIN survey s  ON u.id = s.id
+                 LEFT JOIN tongBTI t ON u.id = t.id
+        WHERE u.id = #{id}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -34,4 +34,7 @@
         UPDATE user SET is_withdraw = false WHERE id = #{userId}
     </update>
 
+    <select id ='getUserIsSurvey'>
+        SELECT is_surveyed FROM user WHERE id = #{userId}
+    </select>
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
userId를 통해 해당 유저의 is_surveyed를 불러올 수 있는 api 생성
dipplan을 추가할 수 있는 api 생성
ocr의 경우, api 호출이 인증을 필요치 않도록 수정
user의 profile을 받아올 수 있는 api 생성 -> 챗봇에서 사용


## 📝작업 내용

- [x] userId를 통해 해당 유저의 is_surveyed를 불러올 수 있는 api 생성
- [x] dipplan을 추가할 수 있는 api 생성
- [x] ocr의 경우, api 호출이 인증을 필요치 않도록 수정
- [x] user의 profile을 받아올 수 있는 api 생성 -> 챗봇에서 사용 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> _리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요_
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
