### PR TITLE
Ojorise 73 add tong bti api

### DIFF
--- a/src/main/java/com/uplus/ojorise/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/uplus/ojorise/config/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter implements Filter {
                 || path.equals("/ojoRise/auth/refresh")
                 || path.startsWith("/ojoRise/auth/kakao")
                 || path.equals("/ojoRise/question")
-                //|| path.equals("/ojoRise/tongbti")
+                || path.equals("/ojoRise/tongbti/info")
         ) {
             chain.doFilter(request, response);
             return;

--- a/src/main/java/com/uplus/ojorise/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/uplus/ojorise/config/JwtAuthenticationFilter.java
@@ -36,7 +36,10 @@ public class JwtAuthenticationFilter implements Filter {
                 || path.contains("favicon")
                 || path.startsWith("/ojoRise/error")
                 || path.equals("/ojoRise/auth/refresh")
-                || path.startsWith("/ojoRise/auth/kakao")) {
+                || path.startsWith("/ojoRise/auth/kakao")
+                || path.equals("/ojoRise/question")
+                //|| path.equals("/ojoRise/tongbti")
+        ) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/uplus/ojorise/config/SecurityConfig.java
+++ b/src/main/java/com/uplus/ojorise/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                                 "/auth/refresh",
                                 "/error",
                                 "/plan/**",
-                                //"/tongbti"
+                                "/tongbti/info",
                                 "/question"
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/uplus/ojorise/config/SecurityConfig.java
+++ b/src/main/java/com/uplus/ojorise/config/SecurityConfig.java
@@ -35,7 +35,9 @@ public class SecurityConfig {
                                 "/auth/kakao/**",
                                 "/auth/refresh",
                                 "/error",
-                                "/plan/**"
+                                "/plan/**",
+                                //"/tongbti"
+                                "/question"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/uplus/ojorise/controller/QuestionController.java
+++ b/src/main/java/com/uplus/ojorise/controller/QuestionController.java
@@ -1,0 +1,29 @@
+package com.uplus.ojorise.controller;
+
+import com.uplus.ojorise.domain.Question;
+import com.uplus.ojorise.domain.TongBTI;
+import com.uplus.ojorise.service.QuestionService;
+import com.uplus.ojorise.service.TongBTIService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/question")
+@RequiredArgsConstructor
+public class QuestionController {
+    private final QuestionService questionService;
+
+    @GetMapping
+    @Operation(summary = "질문 목록 조회", description = "통bti 모든 질문과 선택지를 반환합니다.")
+    public ResponseEntity<List<Question>> getAllQuestions() {
+        return ResponseEntity.ok(questionService.getAllQuestions());
+    }
+}

--- a/src/main/java/com/uplus/ojorise/controller/TongBTIController.java
+++ b/src/main/java/com/uplus/ojorise/controller/TongBTIController.java
@@ -1,11 +1,12 @@
 package com.uplus.ojorise.controller;
 
-import com.uplus.ojorise.domain.Question;
 import com.uplus.ojorise.domain.TongBTI;
+import com.uplus.ojorise.dto.TongBTIRequest;
 import com.uplus.ojorise.service.TongBTIService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -26,12 +27,29 @@ public class TongBTIController {
             TongBTI result = tongBTIService.getTongResult(accessToken);
 
             if (result == null) {
-                return ResponseEntity.ok(Map.of("tongResult",""));
+                return ResponseEntity.ok(Map.of("tongResult", ""));
             }
 
-            return ResponseEntity.ok(Map.of("tongResult",result.getTongResult()));
+            return ResponseEntity.ok(Map.of("tongResult", result.getTongName()));
         } catch (Exception e) {
             return ResponseEntity.status(500).body("조회 실패: " + e.getMessage());
         }
+    }
+
+    @Operation(
+            summary = "통BTI 결과 저장",
+            description = "프론트에서 계산된 통BTI 유형(tongName)을 받아서, 해당 유저의 결과를 저장합니다."
+    )
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> createTongBTI(@RequestBody TongBTIRequest request, Authentication auth) {
+        String tongName = request.getTongName();
+        if (tongName == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Missing tongName"));
+        }
+
+        Long userId = (Long) auth.getPrincipal();
+        Long tongId = tongBTIService.saveTongBTI(userId, tongName);
+
+        return ResponseEntity.ok(Map.of("id", tongId, "tongName", tongName));
     }
 }

--- a/src/main/java/com/uplus/ojorise/controller/TongBTIController.java
+++ b/src/main/java/com/uplus/ojorise/controller/TongBTIController.java
@@ -1,5 +1,6 @@
 package com.uplus.ojorise.controller;
 
+import com.uplus.ojorise.domain.Question;
 import com.uplus.ojorise.domain.TongBTI;
 import com.uplus.ojorise.service.TongBTIService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -7,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
 import java.util.Map;
 
 @RestController

--- a/src/main/java/com/uplus/ojorise/controller/TongBTIController.java
+++ b/src/main/java/com/uplus/ojorise/controller/TongBTIController.java
@@ -1,6 +1,7 @@
 package com.uplus.ojorise.controller;
 
 import com.uplus.ojorise.domain.TongBTI;
+import com.uplus.ojorise.dto.TongBTIPlanResponse;
 import com.uplus.ojorise.dto.TongBTIRequest;
 import com.uplus.ojorise.service.TongBTIService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,4 +53,16 @@ public class TongBTIController {
 
         return ResponseEntity.ok(Map.of("id", tongId, "tongName", tongName));
     }
+
+    @Operation(summary = "통BTI 유형으로 요금제 상세 조회", description = "tongName을 기반으로 통BTI 설명 + 요금제 상세 정보를 조회합니다.")
+    @GetMapping("/info")
+    public ResponseEntity<?> getTongBTIInfo(@RequestParam String tongName) {
+        try {
+            TongBTIPlanResponse response = tongBTIService.getTongBTIWithPlanInfo(tongName);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("조회 실패: " + e.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/com/uplus/ojorise/domain/Question.java
+++ b/src/main/java/com/uplus/ojorise/domain/Question.java
@@ -1,0 +1,11 @@
+package com.uplus.ojorise.domain;
+
+import lombok.Data;
+
+@Data
+public class Question {
+    private int questionId;
+    private String questionTitle;
+    private String answerOne;
+    private String answerTwo;
+}

--- a/src/main/java/com/uplus/ojorise/domain/TongBTI.java
+++ b/src/main/java/com/uplus/ojorise/domain/TongBTI.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class TongBTI {
-    private Long tongId;
-    private Long id;
-    private String tongResult;
+    private Integer tongId;
+    private Integer planId;
+    private String  tongName;
 }

--- a/src/main/java/com/uplus/ojorise/dto/TongBTIPlanResponse.java
+++ b/src/main/java/com/uplus/ojorise/dto/TongBTIPlanResponse.java
@@ -1,0 +1,26 @@
+package com.uplus.ojorise.dto;
+
+import lombok.Data;
+
+@Data
+public class TongBTIPlanResponse {
+    private int tongId;
+    private String tongName;
+    private String tongDescription;
+
+    private int planId;
+    private String planName;
+    private String baseDataGb;
+    private String dailyDataGb;
+    private String sharingDataGb;
+    private int monthlyFee;
+    private String voiceCallPrice;
+    private String sms;
+    private Integer throttleSpeedKbps;
+    private String eligibility;
+    private String mobileType;
+    private boolean isOnline;
+    private String planUrl;
+    private String telecomProvider;
+    private String planDescription;
+}

--- a/src/main/java/com/uplus/ojorise/dto/TongBTIRequest.java
+++ b/src/main/java/com/uplus/ojorise/dto/TongBTIRequest.java
@@ -1,0 +1,8 @@
+package com.uplus.ojorise.dto;
+
+import lombok.Data;
+
+@Data
+public class TongBTIRequest {
+    private String tongName;
+}

--- a/src/main/java/com/uplus/ojorise/mapper/QuestionMapper.java
+++ b/src/main/java/com/uplus/ojorise/mapper/QuestionMapper.java
@@ -1,14 +1,13 @@
 package com.uplus.ojorise.mapper;
 
 import com.uplus.ojorise.domain.Question;
-import com.uplus.ojorise.domain.TongBTI;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
 
 @Mapper
-public interface TongBTIMapper {
-    TongBTI getResult(@Param("id") Long id);
+public interface QuestionMapper {
+    @Select("SELECT * FROM question")
+    List<Question> findAll();
 }

--- a/src/main/java/com/uplus/ojorise/mapper/TongBTIMapper.java
+++ b/src/main/java/com/uplus/ojorise/mapper/TongBTIMapper.java
@@ -1,12 +1,9 @@
 package com.uplus.ojorise.mapper;
 
-import com.uplus.ojorise.domain.Question;
 import com.uplus.ojorise.domain.TongBTI;
+import com.uplus.ojorise.dto.TongBTIPlanResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Select;
-
-import java.util.List;
 
 @Mapper
 public interface TongBTIMapper {
@@ -15,4 +12,6 @@ public interface TongBTIMapper {
     Long findTongIdByName(@Param("tongName") String tongName);
 
     void insertTongBTIResult(@Param("userId") Long userId, @Param("tongId") Long tongId);
+
+    TongBTIPlanResponse findTongBTIWithPlan(@Param("tongName") String tongName);
 }

--- a/src/main/java/com/uplus/ojorise/mapper/TongBTIMapper.java
+++ b/src/main/java/com/uplus/ojorise/mapper/TongBTIMapper.java
@@ -11,4 +11,8 @@ import java.util.List;
 @Mapper
 public interface TongBTIMapper {
     TongBTI getResult(@Param("id") Long id);
+
+    Long findTongIdByName(@Param("tongName") String tongName);
+
+    void insertTongBTIResult(@Param("userId") Long userId, @Param("tongId") Long tongId);
 }

--- a/src/main/java/com/uplus/ojorise/service/QuestionService.java
+++ b/src/main/java/com/uplus/ojorise/service/QuestionService.java
@@ -1,0 +1,18 @@
+package com.uplus.ojorise.service;
+
+import com.uplus.ojorise.domain.Question;
+import com.uplus.ojorise.mapper.QuestionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+    private final QuestionMapper questionMapper;
+
+    public List<Question> getAllQuestions() {
+        return questionMapper.findAll();
+    }
+}

--- a/src/main/java/com/uplus/ojorise/service/TongBTIService.java
+++ b/src/main/java/com/uplus/ojorise/service/TongBTIService.java
@@ -16,4 +16,12 @@ public class TongBTIService {
         Long userId = jwtUtil.getUserIdFromToken(accessToken);
         return tongBTIMapper.getResult(userId);
     }
+
+    public Long saveTongBTI(Long userId, String tongName) {
+        Long tongId = tongBTIMapper.findTongIdByName(tongName);
+        if (tongId == null) throw new RuntimeException("해당 유형 없음");
+
+        tongBTIMapper.insertTongBTIResult(userId, tongId);
+        return tongId;
+    }
 }

--- a/src/main/java/com/uplus/ojorise/service/TongBTIService.java
+++ b/src/main/java/com/uplus/ojorise/service/TongBTIService.java
@@ -1,6 +1,7 @@
 package com.uplus.ojorise.service;
 
 import com.uplus.ojorise.domain.TongBTI;
+import com.uplus.ojorise.dto.TongBTIPlanResponse;
 import com.uplus.ojorise.mapper.TongBTIMapper;
 import com.uplus.ojorise.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,9 @@ public class TongBTIService {
 
         tongBTIMapper.insertTongBTIResult(userId, tongId);
         return tongId;
+    }
+
+    public TongBTIPlanResponse getTongBTIWithPlanInfo(String tongName) {
+        return tongBTIMapper.findTongBTIWithPlan(tongName);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,10 @@ spring.datasource.hikari.idle-timeout=600000
 spring.datasource.hikari.max-lifetime=1800000
 spring.datasource.hikari.auto-commit=true
 
+#ocr
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
 #log level Setting
 logging.level.root=info
 logging.level.com.uplus.ojorise=debug
@@ -49,7 +53,7 @@ springdoc.default-produces-media-type=application/json;charset=UTF-8
 # swagger setting >> Failed to start bean 'documentationPluginsBootstrapper'; error
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 
-kakao-api-key=${KAKAO_API_KEY}
-kakao-redirect-api=${KAKAO_REDIRECT_URI}
-kakao-client-secret=${KAKAO_CLIENT_SECRET}
-jwt-secret=${JWT_SECRET}
+KAKAO_API_KEY=c254f7051b846f8262ef74ac58182336
+KAKAO_REDIRECT_URI=http://localhost:8080/ojoRise/auth/kakao/callback
+KAKAO_CLIENT_SECRET=Xyut6k5MG5EhAVoCQqzqfGZeaTL4KOoo
+JWT_SECRET=ojoRise0123456789abcdef0123456789abcdef

--- a/src/main/resources/mapper/TongBTIMapper.xml
+++ b/src/main/resources/mapper/TongBTIMapper.xml
@@ -26,4 +26,30 @@
         VALUES (#{userId}, #{tongId})
     </insert>
 
+    <select id="findTongBTIWithPlan" resultType="com.uplus.ojorise.dto.TongBTIPlanResponse">
+        SELECT
+            t.tong_id AS tongId,
+            t.tong_name AS tongName,
+            t.description AS tongDescription,
+            p.plan_id AS planId,
+            p.name AS planName,
+            p.base_data_gb,
+            p.daily_data_gb,
+            p.sharing_data_gb,
+            p.monthly_fee,
+            p.voice_call_price,
+            p.sms,
+            p.throttle_speed_kbps,
+            p.eligibility,
+            p.mobile_type,
+            p.is_online,
+            p.plan_url,
+            p.telecom_provider,
+            p.description AS planDescription
+        FROM TongBTI t
+                 JOIN Plan p ON t.plan_id = p.plan_id
+        WHERE t.tong_name = #{tongName}
+            LIMIT 1
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/TongBTIMapper.xml
+++ b/src/main/resources/mapper/TongBTIMapper.xml
@@ -6,10 +6,24 @@
 <mapper namespace="com.uplus.ojorise.mapper.TongBTIMapper">
 
     <select id="getResult" resultType="com.uplus.ojorise.domain.TongBTI">
-        SELECT tong_result AS tongResult
-        FROM tongBTI
-        WHERE id = #{id}
+        SELECT t.tong_id AS tongId,
+               t.tong_name AS tongName,
+               t.plan_id AS planId
+        FROM TongBTIResult r
+                 JOIN TongBTI t ON r.tong_id = t.tong_id
+        WHERE r.id = #{id}
             LIMIT 1
     </select>
+
+    <!-- findTongIdByName -->
+    <select id="findTongIdByName" resultType="long">
+        SELECT tong_id FROM TongBTI WHERE tong_name = #{tongName}
+    </select>
+
+    <!-- insertTongBTIResult -->
+    <insert id="insertTongBTIResult">
+        INSERT INTO TongBTIResult (id, tong_id)
+        VALUES (#{userId}, #{tongId})
+    </insert>
 
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
OJORISE-73-add-tongBTI-api

## 📝작업 내용

- FEAT: 통BTI 유형명으로 요금제 상세 정보 조회 기능 추가
- FEAT: 바뀐 DB 구조에 맞춰 통BTI 결과 저장 및 결과 조회 API 수정
- FEAT: 통BTI 질문 목록 조회를 위한 GET API 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/535fd2e9-0232-492c-86b7-e1e52927e006)


## 💬리뷰 요구사항(선택)
> _리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요_
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
